### PR TITLE
Fix: python_interpreter on delegation

### DIFF
--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -99,6 +99,9 @@ def run_interpreter_discovery_if_necessary(s, task_vars, action, rediscover_pyth
         interpreter_name = 'python'
         discovered_interpreter_config = u'discovered_interpreter_%s' % interpreter_name
         
+        if task_vars.get('ansible_delegated_vars', False):
+           rediscover_python=True
+
         if task_vars.get('ansible_facts') is None:
            task_vars['ansible_facts'] = {}
 


### PR DESCRIPTION
This should fix the 'missing python interpreter' error when running tasks on delegation mode between hosts with different python setup